### PR TITLE
Filter method throws from averages, allow constructor parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,13 @@ function Gas (runner) {
 
         // Compile per method stats
         methodMap && block.transactions.forEach(tx => {
-          const input = web3.eth.getTransaction(tx).input;
+          const transaction = web3.eth.getTransaction(tx);
           const receipt = web3.eth.getTransactionReceipt(tx);
-          const id = stats.getMethodID( input );
-          if (methodMap[id]){
+
+          const id = stats.getMethodID( transaction.input );
+          const threw = receipt.gasUsed === transaction.gas;  // Change this @ Byzantium
+
+          if (methodMap[id] && !threw){
             methodMap[id].gasData.push(receipt.gasUsed);
             methodMap[id].numberOfCalls++;
           }
@@ -57,7 +60,10 @@ function Gas (runner) {
         const receipt = web3.eth.getTransactionReceipt(tx);
 
         if (receipt.contractAddress){
-          const match = deployMap.filter(contract => contract.binary === transaction.input)[0];
+          const match = deployMap.filter(contract => {
+            return (transaction.input.indexOf(contract.binary) === 0)
+          })[0];
+
           match && match.gasData.push(receipt.gasUsed);
         }
       });

--- a/mock/contracts/VariableConstructor.sol
+++ b/mock/contracts/VariableConstructor.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.4.15;
+
+import "./VariableCosts.sol";
+
+contract VariableConstructor is VariableCosts {
+  string name;
+  function VariableConstructor(string _name){
+    name = _name;
+  }
+}

--- a/mock/contracts/VariableCosts.sol
+++ b/mock/contracts/VariableCosts.sol
@@ -19,4 +19,8 @@ contract VariableCosts is Wallet {
   function unusedMethod(address a) public {
     map[1000] = a;
   }
+
+  function methodThatThrows(bool err) public {
+    require(!err);
+  }
 }

--- a/mock/migrations/2_deploy_contracts.js
+++ b/mock/migrations/2_deploy_contracts.js
@@ -2,6 +2,7 @@ var ConvertLib = artifacts.require('./ConvertLib.sol')
 var MetaCoin = artifacts.require('./MetaCoin.sol')
 var Wallet = artifacts.require('./Wallets/Wallet.sol')
 var VariableCosts = artifacts.require('./VariableCosts.sol')
+var VariableConstructor = artifacts.require('./VariableConstructor');
 
 module.exports = function (deployer) {
   deployer.deploy(ConvertLib);
@@ -9,4 +10,5 @@ module.exports = function (deployer) {
   deployer.deploy(MetaCoin);
   deployer.deploy(Wallet);
   deployer.deploy(VariableCosts);
+  deployer.deploy(VariableConstructor)
 }

--- a/mock/test/variableconstructor.js
+++ b/mock/test/variableconstructor.js
@@ -1,0 +1,18 @@
+const VariableConstructor = artifacts.require('./VariableConstructor.sol');
+
+contract('VariableConstructor', accounts => {
+
+  it('should should initialize with a short string', async () => {
+    await VariableConstructor.new('Exit Visa');
+  });
+
+  it('should should initialize with a medium length string', async () => {
+    await VariableConstructor.new('Enclosed is my application for residency');
+  });
+
+  it('should should initialize with a long string', async () => {
+    let msg = 'Enclosed is my application for permanent residency in NewZealand.';
+    msg += 'I am a computer programmer.';
+    await VariableConstructor.new(msg);
+  });
+});

--- a/mock/test/variablecosts.js
+++ b/mock/test/variablecosts.js
@@ -37,4 +37,13 @@ contract('VariableCosts', accounts => {
     await instance.addToMap(five);
     await instance.removeFromMap(one);
   })
+
+  it('methods that do not throw', async() => {
+    await instance.methodThatThrows(false);
+  });
+
+  it('methods that throw', async() => {
+    try {await instance.methodThatThrows(true)}
+    catch(e){}
+  });
 })


### PR DESCRIPTION
Closes #28 
Closes #29 

Fixes a bug in the PR for #25 that caused contracts with constructor arguments not to appear in the deployment metrics