### PR TITLE
Filter throwing contract deployments

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,9 @@ function Gas (runner) {
       block && block.transactions.forEach(tx => {
         const transaction = web3.eth.getTransaction(tx)
         const receipt = web3.eth.getTransactionReceipt(tx);
+        const threw = receipt.gasUsed === transaction.gas;  // Change this @ Byzantium
 
-        if (receipt.contractAddress){
+        if (receipt.contractAddress && !threw){
           const match = deployMap.filter(contract => {
             return (transaction.input.indexOf(contract.binary) === 0)
           })[0];

--- a/mock/package-lock.json
+++ b/mock/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes bug in #30 that allowed failed contract deployments to show up in stats.