### PR TITLE
Run epilogue async, improve table readability

### DIFF
--- a/gasStats.js
+++ b/gasStats.js
@@ -77,7 +77,7 @@ async function generateGasStatsReport (methodMap, deployMap) {
     stats.max = sortedData[sortedData.length - 1]
 
     const uniform = (stats.min === stats.max)
-    stats.min = (uniform) ? '-' : stats.min.toString().yellow
+    stats.min = (uniform) ? '-' : stats.min.toString().cyan
     stats.max = (uniform) ? '-' : stats.max.toString().red
 
     stats.numberOfCalls = data.numberOfCalls.toString().grey
@@ -112,7 +112,7 @@ async function generateGasStatsReport (methodMap, deployMap) {
     stats.max = sortedData[sortedData.length - 1]
 
     const uniform = (stats.min === stats.max)
-    stats.min = (uniform) ? '-' : stats.min.toString().yellow
+    stats.min = (uniform) ? '-' : stats.min.toString().cyan
     stats.max = (uniform) ? '-' : stats.max.toString().red
 
     const section = []
@@ -130,15 +130,15 @@ async function generateGasStatsReport (methodMap, deployMap) {
   const table = new Table({
     style: {head: [], border: [], 'padding-left': 2, 'padding-right': 2},
     chars: {
-      'mid': '·', 'top-mid': '·', 'left-mid': '·', 'mid-mid': '·', 'right-mid': '·',
+      'mid': '·', 'top-mid': '|', 'left-mid': '·', 'mid-mid': '|', 'right-mid': '·',
       'top-left': '·', 'top-right': '·', 'bottom-left': '·', 'bottom-right': '·',
-      'middle': '·', 'top': '-', 'bottom': '-', 'bottom-mid': '-'
+      'middle': '·', 'top': '-', 'bottom': '-', 'bottom-mid': '|'
     }
   })
 
   // Format and load methods metrics
   let title = [
-    {hAlign: 'center', colSpan: 5, content: 'Gas Usage Metrics'.green.bold},
+    {hAlign: 'center', colSpan: 5, content: 'Gas'.green.bold},
     {hAlign: 'center', colSpan: 2, content: `Block limit: ${blockLimit} gas`.grey }
   ]
 

--- a/index.js
+++ b/index.js
@@ -130,8 +130,9 @@ function Gas (runner) {
   })
 
   runner.on('end', () => {
-    stats.generateGasStatsReport(methodMap, deployMap)
-    self.epilogue()
+    stats
+      .generateGasStatsReport(methodMap, deployMap)
+      .then(() => self.epilogue());
   })
 }
 

--- a/mock/package-lock.json
+++ b/mock/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {

--- a/mock/test/variablecosts.js
+++ b/mock/test/variablecosts.js
@@ -44,4 +44,8 @@ contract('VariableCosts', accounts => {
   it('methods that throw', async() => {
     try { await instance.methodThatThrows(true) } catch (e) {}
   })
+
+  it.skip('prints a table at end of test suites with failures', async() => {
+    assert(false);
+  })
 })


### PR DESCRIPTION
Can't figure out the test failure bug #19. On success epilogue will run async, with a single failure it summarily exits. Might be happening at truffle - they hijack failures to print the events.