### PR TITLE
Fix no table when tests fail bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,10 @@ module.exports = {
 + [windingtree/LifToken](https://github.com/cgewecke/eth-gas-reporter/blob/master/docs/lifToken.md)
 
 ### Usage Notes
-+ Table will not print if any tests fail (this is a bug, possibly rooted in `truffle`).
 + Method calls that throw are filtered from the stats.
 + Not currently shown in the `deployments` table:
   + Contracts that link to libraries
   + Contracts that never get instantiated within the tests (e.g: only deployed in migrations)
-+ Tests that make assumptions about the value of `block.timestamp` sometimes fail using this utility.
 + Tests run slower.
 
 ### Credits

--- a/gasStats.js
+++ b/gasStats.js
@@ -11,6 +11,15 @@ const Table = require('cli-table2')
 const reqCwd = require('req-cwd')
 const abiDecoder = require('abi-decoder')
 
+
+/**
+ * We fetch these async from remote sources / config when the reporter loads because
+ * for unknown reasons mocha exits prematurely if any of the tests fail.
+ */
+let currency;
+let gasPrice;
+let ethPrice;
+
 /**
  * block.gasLimit. Set to a default at declaration but set to the rpc's declared limit
  * at `mapMethodsToContracts`
@@ -54,14 +63,7 @@ function getMethodID (code) {
  * Prints a gas stats table to stdout. Based on Alan Lu's stats for Gnosis
  * @param  {Object} methodMap methods and their gas usage (from mapMethodToContracts)
  */
-async function generateGasStatsReport (methodMap, deployMap) {
-  const {
-    currency,
-    ethPrice,
-    gasPrice
-  } = await getGasAndPriceRates()
-
-  // Compose rows
+function generateGasStatsReport (methodMap, deployMap) {
   const methodRows = []
 
   _.forEach(methodMap, (data, methodId) => {
@@ -213,14 +215,14 @@ async function generateGasStatsReport (methodMap, deployMap) {
  *
  */
 async function getGasAndPriceRates () {
-  let ethPrice
-  let gasPrice
+
   const defaultGasPrice = 5000000000
 
   // Load config
   const config = reqCwd.silent('./.ethgas.js') || {}
-  const currency = config.currency || 'eur'
 
+  // Global to this file...
+  currency = config.currency || 'eur'
   ethPrice = config.ethPrice || null
   gasPrice = config.gasPrice || null
 
@@ -248,12 +250,6 @@ async function getGasAndPriceRates () {
     } catch (error) {
       gasPrice = defaultGasPrice
     }
-  }
-
-  return {
-    currency: currency,
-    ethPrice: ethPrice,
-    gasPrice: gasPrice
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ const stats = require('./gasStats.js')
 const Base = mocha.reporters.Base
 const color = Base.color
 const log = console.log
-module.exports = Gas
+
+// Start getting this data when the reporter loads.
+stats.getGasAndPriceRates();
 
 // Based on the 'Spec' reporter
 function Gas (runner) {
@@ -139,19 +141,14 @@ function Gas (runner) {
   })
 
   runner.on('end', () => {
-    if (!failed){
-      stats
-        .generateGasStatsReport(methodMap, deployMap)
-        .then(() => self.epilogue() );
-    } else {
-      self.epilogue();
-    }
+    stats.generateGasStatsReport(methodMap, deployMap)
+    self.epilogue()
   });
 }
-
-
 
 /**
  * Inherit from `Base.prototype`.
  */
 inherits(Gas, Base)
+
+module.exports = Gas

--- a/mock/package-lock.json
+++ b/mock/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {

--- a/mock/test.sh
+++ b/mock/test.sh
@@ -52,3 +52,4 @@ echo "Visual test with config"
 cp ./config-template.js ./.ethgas.js
 node_modules/.bin/truffle test --network development "$@"
 rm ./.ethgas.js
+0

--- a/mock/test.sh
+++ b/mock/test.sh
@@ -52,4 +52,3 @@ echo "Visual test with config"
 cp ./config-template.js ./.ethgas.js
 node_modules/.bin/truffle test --network development "$@"
 rm ./.ethgas.js
-0

--- a/mock/test/variablecosts.js
+++ b/mock/test/variablecosts.js
@@ -45,7 +45,7 @@ contract('VariableCosts', accounts => {
     try { await instance.methodThatThrows(true) } catch (e) {}
   })
 
-  it.skip('prints a table at end of test suites with failures', async() => {
+  it('prints a table at end of test suites with failures', async() => {
     assert(false);
   })
 })


### PR DESCRIPTION
Resolving #19 by making the table print sync and moving the async price fetches to the top of the reporter load. 

Hacky but likelyhood that data won't resolve by the end of the test run is pretty low. 