### PR TITLE
Get contract names by parsing files

### DIFF
--- a/mock/contracts/MultiContractFile.sol
+++ b/mock/contracts/MultiContractFile.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.4.23;
+
+contract MultiContractFileA {
+  uint x;
+
+  function hello() public {
+    x = 5;
+  }
+}
+
+contract MultiContractFileB {
+  uint x;
+
+  function goodbye() public {
+    x = 5;
+  }
+}

--- a/mock/package-lock.json
+++ b/mock/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6296,6 +6296,11 @@
           }
         }
       }
+    },
+    "solidity-parser-antlr": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz",
+      "integrity": "sha512-g1RWj6m377CBlUBlyffhv4UOO48ue+gL7GlmE9i77N8bxaKgzWvTl1xzvDadaubJoz2euPpk3A7qTPbqkUof1w=="
     },
     "sort-keys": {
       "version": "2.0.0",

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {
@@ -34,6 +34,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "shelljs": "^0.7.8",
+    "solidity-parser-antlr": "^0.2.10",
     "sync-request": "^6.0.0"
   },
   "devDependencies": {

--- a/mock/test/multicontract.js
+++ b/mock/test/multicontract.js
@@ -1,0 +1,17 @@
+const MultiContractFileA = artifacts.require('MultiContractFileA');
+const MultiContractFileB = artifacts.require('MultiContractFileB');
+
+contract('MultiContractFiles', accounts => {
+  let a
+  let b
+
+  beforeEach(async function () {
+    a = await MultiContractFileA.new()
+    b = await MultiContractFileB.new()
+  })
+
+  it('a and b', async function(){
+    await a.hello();
+    await b.goodbye();
+  })
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -6297,6 +6297,11 @@
         }
       }
     },
+    "solidity-parser-antlr": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.2.10.tgz",
+      "integrity": "sha512-g1RWj6m377CBlUBlyffhv4UOO48ue+gL7GlmE9i77N8bxaKgzWvTl1xzvDadaubJoz2euPpk3A7qTPbqkUof1w=="
+    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "shelljs": "^0.7.8",
+    "solidity-parser-antlr": "^0.2.10",
     "sync-request": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds `solidity-parser-antlr` and derives the contract names by parsing the files instead of looking at the file names.