### PR TITLE
Support reStructured text code-block output

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ module.exports = {
 | outputFile | *String* | stdout | File path to write report output to |
 | noColors | *Boolean* | false | Suppress report color. Useful if you are printing to file b/c terminal colorization corrupts the text. |
 | onlyCalledMethods | *Boolean* | false | Omit methods that are never called from report. |
+| rst | *Boolean* | false | Output with a reStructured text code-block directive. Useful if you want to include report in RTD |
+| rstTitle | *String* | '' | Title for reStructured text header (See Travis for example output) |
 
 
 ### Examples

--- a/gasStats.js
+++ b/gasStats.js
@@ -23,6 +23,8 @@ let gasPrice;
 let ethPrice;
 let onlyCalledMethods;
 let outputFile;
+let rst;
+let rstTitle;
 
 /**
  * block.gasLimit. Set to a default at declaration but set to the rpc's declared limit
@@ -154,13 +156,16 @@ function generateGasStatsReport (methodMap, deployMap) {
     deployRows.push(section)
   })
 
+  const leftPad = (rst) ? '  ' : '';
+
   // Format table
   const table = new Table({
     style: {head: [], border: [], 'padding-left': 2, 'padding-right': 2},
     chars: {
-      'mid': '·', 'top-mid': '|', 'left-mid': '·', 'mid-mid': '|', 'right-mid': '·',
-      'top-left': '·', 'top-right': '·', 'bottom-left': '·', 'bottom-right': '·',
-      'middle': '·', 'top': '-', 'bottom': '-', 'bottom-mid': '|'
+      'mid': '·', 'top-mid': '|', 'left-mid': `${leftPad}·`, 'mid-mid': '|', 'right-mid': '·',
+      'left': `${leftPad}|`, 'top-left': `${leftPad}·`, 'top-right': '·',
+      'bottom-left': `${leftPad}·`, 'bottom-right': '·', 'middle': '·', 'top': '-',
+      'bottom': '-', 'bottom-mid': '|'
     }
   })
 
@@ -217,16 +222,20 @@ function generateGasStatsReport (methodMap, deployMap) {
     deployRows.forEach(row => table.push(row))
   }
 
+  let rstOutput = '';
+  if (rst) {
+    rstOutput += `${rstTitle}\n`;
+    rstOutput += `${'='.repeat(rstTitle.length)}\n\n`;
+    rstOutput += `.. code-block:: shell\n\n`;
+  }
+
+  let tableOutput = rstOutput + table.toString();
+
   // export to preferred output
   if (outputFile) {
-    fs.writeFile(outputFile, table.toString(), (err) => {
-      if (err) {
-        console.log('Writing to %s failed', outputFile);
-        console.log(table.toString());
-      }
-    });
+    fs.writeFileSync(outputFile, tableOutput)
   } else {
-    console.log(table.toString())
+    console.log(tableOutput)
   }
 }
 
@@ -261,6 +270,8 @@ async function getGasAndPriceRates (options=null) {
   gasPrice = config.gasPrice || null
   onlyCalledMethods = config.onlyCalledMethods || false
   outputFile = config.outputFile || null
+  rst = config.rst || false
+  rstTitle = config.rstTitle || '';
   colors.enabled = !config.noColors || false
 
   const currencyPath = `https://api.coinmarketcap.com/v1/ticker/ethereum/?convert=${currency.toUpperCase()}`

--- a/mock/config-template.js
+++ b/mock/config-template.js
@@ -13,7 +13,9 @@ module.exports = {
       currency: "chf",
       gasPrice: 21,
       onlyCalledMethods: true,
-      noColors: true
+      noColors: true,
+      rst: true,
+      rstTitle: 'Gas Usage'
     }
   }
 }

--- a/mock/package-lock.json
+++ b/mock/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds options that generate a header & indentation like this:
```shell 
Gas Usage
=========

.. code-block:: shell

  ·----------------------------------------------------------------------------|----------------------------·
  |                                    Gas                                     ·  Block limit: 8000000 gas  │
  ············································|································|·····························
  |  Methods                                  ·          21 gwei/gas           ·       570.17 chf/eth       │
  ·······················|····················|··········|··········|··········|··············|··············
  |  Contract            ·  Method            ·  Min     ·  Max     ·  Avg     ·  # calls     ·  chf (avg)  │
  ·······················|····················|··········|··········|··········|··············|··············
  |  MetaCoin            ·  sendCoin          ·       -  ·       -  ·   50993  ·           1  ·       0.61  │
```

To help make gas report usable in sphinx documentation /  RTD as an appendix.
