### PR TITLE
Add showTimeSpent option to also show how long each test took

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module.exports = {
 | onlyCalledMethods | *Boolean* | false | Omit methods that are never called from report. |
 | rst | *Boolean* | false | Output with a reStructured text code-block directive. Useful if you want to include report in RTD |
 | rstTitle | *String* | '' | Title for reStructured text header (See Travis for example output) |
+| showTimeSpent | *Boolean* | false | Show the amount of time spent as well as the gas consumed |
 
 
 ### Examples

--- a/gasStats.js
+++ b/gasStats.js
@@ -9,7 +9,6 @@ const fs = require('fs')
 const request = require('request-promise-native')
 const shell = require('shelljs')
 const Table = require('cli-table3')
-const reqCwd = require('req-cwd')
 const abiDecoder = require('abi-decoder')
 const parser = require('solidity-parser-antlr');
 const sync = require('./sync');
@@ -252,17 +251,9 @@ function generateGasStatsReport (methodMap, deployMap) {
  *   } = await getGasAndPriceRates()
  *
  */
-async function getGasAndPriceRates (options=null) {
+async function getGasAndPriceRates (config=null) {
 
   const defaultGasPrice = 5
-
-  // Load config / keep .ethgas.js for backward compatibility
-  let config;
-  if (options && options.reporterOptions){
-    config = options.reporterOptions
-  } else {
-    config = reqCwd.silent('./.ethgas.js') || {}
-  }
 
   // Global to this file...
   currency = config.currency || 'eur'

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const mocha = require('mocha')
 const inherits = require('util').inherits
 const sync = require('./sync')
 const stats = require('./gasStats.js')
+const reqCwd = require('req-cwd')
 const Base = mocha.reporters.Base
 const color = Base.color
 const log = console.log
@@ -20,8 +21,16 @@ function Gas (runner, options) {
   let methodMap
   let deployMap
 
+  // Load config / keep .ethgas.js for backward compatibility
+  let config;
+  if (options && options.reporterOptions){
+    config = options.reporterOptions
+  } else {
+    config = reqCwd.silent('./.ethgas.js') || {}
+  }
+
   // Start getting this data when the reporter loads.
-  stats.getGasAndPriceRates(options);
+  stats.getGasAndPriceRates(config);
 
   // ------------------------------------  Helpers -------------------------------------------------
   const indent = () => Array(indents).join('  ')
@@ -111,25 +120,43 @@ function Gas (runner, options) {
 
   runner.on('pass', test => {
     let fmt
+    let fmtArgs
     let gasUsedString
     deployAnalytics(deployMap)
     let gasUsed = methodAnalytics(methodMap)
+    let showTimeSpent = config.showTimeSpent || false
+    let timeSpentString = color(test.speed, '%dms')
+    let consumptionString
     if (gasUsed) {
-      gasUsedString = color('checkmark', ' (%d gas)')
+      gasUsedString = color('checkmark', '%d gas')
 
+      if (showTimeSpent) {
+        consumptionString = ' (' + timeSpentString + ', ' + gasUsedString + ')'
+        fmtArgs = [test.title, test.duration, gasUsed]
+      } else {
+        consumptionString = ' (' + gasUsedString + ')'
+        fmtArgs = [test.title, gasUsed]
+      }
+      
       fmt = indent() +
       color('checkmark', '  ' + Base.symbols.ok) +
       color('pass', ' %s') +
-      gasUsedString
-
-      log(fmt, test.title, gasUsed)
+      consumptionString
     } else {
+      if (showTimeSpent) {
+        consumptionString = ' (' + timeSpentString + ')'
+        fmtArgs = [test.title, test.duration]
+      } else {
+        consumptionString = ''
+        fmtArgs = [test.title]
+      }
+
       fmt = indent() +
         color('checkmark', '  ' + Base.symbols.ok) +
-        color('pass', ' %s')
-
-      log(fmt, test.title)
+        color('pass', ' %s') +
+        consumptionString
     }
+    log.apply(null, [fmt, ...fmtArgs])
   })
 
   runner.on('fail', test => {

--- a/mock/config-template.js
+++ b/mock/config-template.js
@@ -15,7 +15,8 @@ module.exports = {
       onlyCalledMethods: true,
       noColors: true,
       rst: true,
-      rstTitle: 'Gas Usage'
+      rstTitle: 'Gas Usage',
+      showTimeSpent: true
     }
   }
 }


### PR DESCRIPTION
Adds an option to the reporter options to show the time spent as well as the gas consumption.

Notes:
1. Unit tests are currently broken (at least on my system) they fail on master branch when I run `npm run test`:
```
  1) Contract: VariableCosts prints a table at end of test suites with failures:
     AssertionError: Unspecified AssertionError
      at Context.it (test/variablecosts.js:49:5)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```
2. Would you like to default showTimeSpent to true?
3. I had to refactor the 'Load config' section from gasStats.js to index.js


Preview:
![ethgasreporter](https://user-images.githubusercontent.com/3114081/41947284-7c8aa778-796b-11e8-872f-5870992de739.png)
