### PR TITLE
Restore `startBlock` offset in `hook end`

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function Gas (runner, options) {
 
   runner.on('test', () => { deployStartBlock = sync.blockNumber() })
 
-  runner.on('hook end', () => { startBlock = sync.blockNumber() })
+  runner.on('hook end', () => { startBlock = sync.blockNumber() + 1 })
 
   runner.on('pass', test => {
     let fmt


### PR DESCRIPTION
#81 

This was a refactoring mistake. Might have to add a test for this too.