### PR TITLE
Support truffle working_directory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ module.exports = {
   and we have to collect gas data synchronously from the client as your tests run. Sync requests 
   fail with an in memory provider because they block the thread and prevent a 
   response. (Pro-tip courtesy of [@fosgate29](https://github.com/fosgate29)).
++ If the truffle "working_directory" flag is set, that directory will be used as the location of
+  the truffle project from which contracts will be read.
 
 ### Contributions
 Please feel free to open a PR (or an issue) for anything. The units are an integration test and one of them is expected to fail, verifying that the table prints at the end of a suite even when there are errors. If you're adding an option, you can vaildate it in CI by adding it to the mock options config located [here](https://github.com/cgewecke/eth-gas-reporter/blob/master/mock/config-template.js#L13-L19). 

--- a/gasStats.js
+++ b/gasStats.js
@@ -343,7 +343,7 @@ function getContractNames(filePath){
  *   ....
  * ]
  */
-function mapMethodsToContracts (truffleArtifacts) {
+function mapMethodsToContracts (config, truffleArtifacts) {
   const methodMap = {}
   const deployMap = []
   const abis = []
@@ -351,7 +351,8 @@ function mapMethodsToContracts (truffleArtifacts) {
   const block = sync.getLatestBlock()
   blockLimit = parseInt(block.gasLimit, 16);
 
-  const files = shell.ls('./contracts/**/*.sol')
+  const workingDirectory = config.working_directory ? config.working_directory : './';
+  const files = shell.ls(path.join(workingDirectory, 'contracts/**/*.sol'))
 
   // For each file
   files.forEach(file => {

--- a/index.js
+++ b/index.js
@@ -24,7 +24,11 @@ function Gas (runner, options) {
   // Load config / keep .ethgas.js for backward compatibility
   let config;
   if (options && options.reporterOptions){
-    config = options.reporterOptions
+    const argv = require('minimist')(process.argv.slice(2))
+    config = {
+      ...options.reporterOptions,
+      ...argv
+    }
   } else {
     config = reqCwd.silent('./.ethgas.js') || {}
   }
@@ -94,7 +98,7 @@ function Gas (runner, options) {
 
   // ------------------------------------  Runners -------------------------------------------------
   runner.on('start', () => {
-    ({ methodMap, deployMap } = stats.mapMethodsToContracts(artifacts))
+    ({ methodMap, deployMap } = stats.mapMethodsToContracts(config, artifacts))
   })
 
   runner.on('suite', suite => {


### PR DESCRIPTION
This allows gas reporting when running "truffle test" from a directory outside the truffle project