### PR TITLE
Undeployed contracts

### DIFF
--- a/gasStats.js
+++ b/gasStats.js
@@ -264,7 +264,7 @@ function generateGasStatsReport (methodMap, deployMap, contractNameFromCodeHash)
  *   } = await getGasAndPriceRates()
  *
  */
-async function getGasAndPriceRates (config=null) {
+async function getGasAndPriceRates (config={}) {
 
   const defaultGasPrice = 5
 

--- a/gasStats.js
+++ b/gasStats.js
@@ -22,6 +22,7 @@ let currency;
 let gasPrice;
 let ethPrice;
 let onlyCalledMethods;
+let includeUndeployedContracts;
 let outputFile;
 let rst;
 let rstTitle;
@@ -99,7 +100,7 @@ function generateGasStatsReport (methodMap, deployMap, contractNameFromCodeHash)
   _.forEach(methodMap, (data, methodId) => {
     if (!data) return
 
-    if(!deployedContracts[data.contract]) return // skip contract that were not deployed
+    if(!deployedContracts[data.contract] && !includeUndeployedContracts) return // skip contract that were not deployed
     let stats = {}
 
     if (data.gasData.length) {
@@ -273,6 +274,7 @@ async function getGasAndPriceRates (config={}) {
   ethPrice = config.ethPrice || null
   gasPrice = config.gasPrice || null
   onlyCalledMethods = (config.onlyCalledMethods === false) ? false : true;
+  includeUndeployedContracts = (config.includeUndeployedContracts === true) ? true : false;
   outputFile = config.outputFile || null
   rst = config.rst || false
   rstTitle = config.rstTitle || '';
@@ -407,6 +409,7 @@ function mapMethodsToContracts (truffleArtifacts, srcPath) {
 
         if (hasName && !isConstant && !isEvent && !isInterface) {
           methodMap[name + '_' + key] = {
+            key: key,
             contract: name,
             method: methodIDs[key].name,
             gasData: [],


### PR DESCRIPTION
Some of my contracts are meant to be deployed dynamically by other contracts, and I've written my tests to reproduce this behavior.  Because these contracts are never explicitly deployed, their methods do not show up in the final report.  I've added an option called `includeUndeployedContracts` to correct this.  It seems like others might find this change useful as well.

