### PR TITLE
Fix bug with undeployed but linked contracts

### DIFF
--- a/gasStats.js
+++ b/gasStats.js
@@ -382,9 +382,9 @@ function mapMethodsToContracts (truffleArtifacts, srcPath) {
       }
       deployMap.push(contractInfo)
 
-      // report the gas used during initial truffle migration too :
+      // Report the gas used during initial truffle migration too :
       const networkDeployment = contract.networks[networkId]
-      if (networkDeployment) {
+      if (networkDeployment && networkDeployment.transactionHash) {
         const code = sync.getCode(networkDeployment.address);
         const hash = sha1(code);
         contractNameFromCodeHash[hash] = name;

--- a/mock/contracts/Undeployed.sol
+++ b/mock/contracts/Undeployed.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.5.0;
+
+import "./ConvertLib.sol";
+
+contract Undeployed {
+    event Amount(uint val);
+
+    function f() public {
+      uint a = ConvertLib.convert(5,5);
+      emit Amount(a);
+    }
+}

--- a/mock/migrations/2_deploy_contracts.js
+++ b/mock/migrations/2_deploy_contracts.js
@@ -3,10 +3,12 @@ var MetaCoin = artifacts.require('./MetaCoin.sol')
 var Wallet = artifacts.require('./Wallets/Wallet.sol')
 var VariableCosts = artifacts.require('./VariableCosts.sol')
 var VariableConstructor = artifacts.require('./VariableConstructor')
+var Undeployed = artifacts.require('./Undeployed')
 
 module.exports = function (deployer) {
   deployer.deploy(ConvertLib)
   deployer.link(ConvertLib, MetaCoin)
+  deployer.link(ConvertLib, Undeployed)
   deployer.deploy(MetaCoin)
   deployer.deploy(Wallet)
   deployer.deploy(VariableCosts)


### PR DESCRIPTION
Diagnosis of this problem in #104 [here](https://github.com/cgewecke/eth-gas-reporter/issues/104#issuecomment-438712466). An undeployed contract can acquire a network profile if it's linked in the migrations. In these cases there's no tx hash to pull data for and the reporter crashes while trying. 

Added an example of this to the tests.