### PR TITLE
Add support for proxy / delegate call

### DIFF
--- a/lib/artifactor.js
+++ b/lib/artifactor.js
@@ -64,9 +64,7 @@ class Artifactor {
     contract.bytecode = this._normalizeBytecode(artifact.bytecode);
     contract.deployedBytecode = this._normalizeBytecode(deployedBytecode);
 
-    if (artifact.networks && artifact.networks.length) {
-      deployed = artifact.networks[this.networkId];
-    }
+    deployed = artifact.networks[this.networkId];
 
     // Migrations deployed data
     if (deployed) {

--- a/lib/artifactor.js
+++ b/lib/artifactor.js
@@ -48,14 +48,25 @@ class Artifactor {
    * @return {Object}              egr artifact
    */
   _truffleArtifactor(contractName) {
+    let deployed;
+    let deployedBytecode;
     const contract = {};
-    const truffleContract = artifacts.require(contractName);
+    const artifact = artifacts.require(contractName);
 
-    contract.abi = truffleContract.abi;
-    contract.bytecode = truffleContract.bytecode;
-    contract.deployedBytecode = truffleContract.deployedBytecode;
+    // Temporary (buidler)
+    try {
+      deployedBytecode = artifact.deployedBytecode;
+    } catch (err) {
+      //
+    }
 
-    const deployed = truffleContract.networks[this.networkId];
+    contract.abi = artifact.abi;
+    contract.bytecode = this._normalizeBytecode(artifact.bytecode);
+    contract.deployedBytecode = this._normalizeBytecode(deployedBytecode);
+
+    if (artifact.networks && artifact.networks.length) {
+      deployed = artifact.networks[this.networkId];
+    }
 
     // Migrations deployed data
     if (deployed) {
@@ -66,6 +77,20 @@ class Artifactor {
     }
 
     return contract;
+  }
+
+  _normalizeBytecode(code) {
+    if (typeof code === "string" && code.length && !this._isHexPrefixed(code)) {
+      return `0x${code}`;
+    } else if (!code) {
+      return `0x`;
+    } else {
+      return code;
+    }
+  }
+
+  _isHexPrefixed(str) {
+    return str.slice(0, 2) === "0x";
   }
 }
 

--- a/lib/artifactor.js
+++ b/lib/artifactor.js
@@ -8,7 +8,8 @@ const SyncRequest = require("./syncRequest");
  * const contract = artifactor.require('Example');
  * {
  *   abi: [etc...],
- *   bytecode: "0x" + contract.evm.bytecode.object, // Solidity JSON i/o output field
+ *   bytecode: "0x" + contract.evm.bytecode.object,                // (solc key name)
+ *   deployedBytecode: "0x" + contract.evm.deployedBytecode.object // (solc key name)
  *
  *   // Optional - pre-test contract deployments  e.g from `truffle migrate`
  *   // TODO: We don't need the address if we have the tx hash.
@@ -50,9 +51,9 @@ class Artifactor {
     const contract = {};
     const truffleContract = artifacts.require(contractName);
 
-    // Note: bytecode: "0x" + contract.evm.bytecode.object,
     contract.abi = truffleContract.abi;
     contract.bytecode = truffleContract.bytecode;
+    contract.deployedBytecode = truffleContract.deployedBytecode;
 
     const deployed = truffleContract.networks[this.networkId];
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,7 +16,7 @@ class Config {
     this.srcPath = options.src || "contracts";
     this.artifactType = options.artifactType || "truffle_v.5.0";
     this.noColors = options.noColors;
-    this.proxyResolver = options.proxyResolver || "EtherRouter";
+    this.proxyResolver = options.proxyResolver || null;
 
     this.excludeContracts = Array.isArray(options.excludeContracts)
       ? options.excludeContracts

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,7 @@ class Config {
     this.srcPath = options.src || "contracts";
     this.artifactType = options.artifactType || "truffle_v.5.0";
     this.noColors = options.noColors;
+    this.proxyResolver = options.proxyResolver || null;
 
     this.excludeContracts = Array.isArray(options.excludeContracts)
       ? options.excludeContracts

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,7 +16,7 @@ class Config {
     this.srcPath = options.src || "contracts";
     this.artifactType = options.artifactType || "truffle_v.5.0";
     this.noColors = options.noColors;
-    this.proxyResolver = options.proxyResolver || null;
+    this.proxyResolver = options.proxyResolver || "EtherRouter";
 
     this.excludeContracts = Array.isArray(options.excludeContracts)
       ? options.excludeContracts

--- a/lib/gasData.js
+++ b/lib/gasData.js
@@ -104,7 +104,7 @@ class GasData {
    */
   trackNameByAddress(name, address) {
     const code = this.sync.getCode(address);
-    const hash = sha1(code);
+    const hash = code ? sha1(code) : null;
     this.codeHashMap[hash] = name;
   }
 
@@ -115,7 +115,7 @@ class GasData {
    */
   getNameByAddress(address) {
     const code = this.sync.getCode(address);
-    const hash = sha1(code);
+    const hash = code ? sha1(code) : null;
     return this.codeHashMap[hash];
   }
 
@@ -127,6 +127,8 @@ class GasData {
    * @return {Object}       this.deployments entry
    */
   getContractByDeploymentInput(input) {
+    if (!input) return null;
+
     const matches = this.deployments.filter(item =>
       utils.matchBinaries(input, item.bytecode)
     );

--- a/lib/gasData.js
+++ b/lib/gasData.js
@@ -54,6 +54,7 @@ class GasData {
           const contractInfo = {
             name: name,
             bytecode: contract.bytecode,
+            deployedBytecode: contract.deployedBytecode,
             gasData: []
           };
           this.deployments.push(contractInfo);
@@ -136,6 +137,26 @@ class GasData {
     // Filter interfaces
     return matches && matches.length
       ? matches.find(item => item.bytecode !== "0x")
+      : null;
+  }
+
+  /**
+   * Compares code at an address to the deployedBytecode for all
+   * compiled contracts and returns the relevant item.
+   * Ignores interfaces.
+   * @param  {String} code  result of web3.eth.getCode
+   * @return {Object}       this.deployments entry
+   */
+  getContractByDeployedBytecode(code) {
+    if (!code) return null;
+
+    const matches = this.deployments.filter(item =>
+      utils.matchBinaries(code, item.deployedBytecode)
+    );
+
+    // Filter interfaces
+    return matches && matches.length
+      ? matches.find(item => item.deployedBytecode !== "0x")
       : null;
   }
 

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -10,7 +10,6 @@ class ProxyResolver {
     if (typeof config.proxyResolver === "function") {
       this.resolve = config.proxyResolver.bind(this);
     } else if (config.proxyResolver === "EtherRouter") {
-      console.log("attaching to _etherRouter");
       this.resolve = this._etherRouter;
     } else if (config.proxyResolver === "ZOS@2") {
       this.resolve = this._zos2;
@@ -69,8 +68,10 @@ class ProxyResolver {
       return this._default(transaction);
     }
 
-    contractAddress = ethers.utils.hexStripZeros(contractAddress);
-    return this.data.getNameByAddress(contractAddress);
+    // Geth returns `undefined` for Truffle's solidity tests here.
+    if (contractAddress) {
+      return ethers.utils.hexStripZeros(contractAddress);
+    }
   }
 }
 

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -14,7 +14,7 @@ class ProxyResolver {
     } else if (config.proxyResolver === "ZOS@2") {
       this.resolve = this._zos2;
     } else {
-      this.resolve = this._default;
+      this.resolve = this.firstMatch;
     }
   }
 
@@ -24,7 +24,7 @@ class ProxyResolver {
    * @param  {Object} transaction result of web3.eth.getTransaction
    * @return {String}             contract name
    */
-  _default(transaction) {
+  firstMatch(transaction) {
     const signature = transaction.input.slice(2, 10);
     const matches = this.data.getAllContractsWithMethod(signature);
 
@@ -40,9 +40,10 @@ class ProxyResolver {
    */
   _etherRouter(transaction) {
     let contractAddress;
+    let contractName;
+
     try {
       const ABI = ["function resolver()", "function lookup(bytes4 sig)"];
-
       const iface = new ethers.utils.Interface(ABI);
       const signature = transaction.input.slice(0, 10);
 
@@ -65,12 +66,25 @@ class ProxyResolver {
       );
     } catch (err) {
       this.unresolvedCalls++;
-      return this._default(transaction);
+      return;
     }
 
     // Geth returns `undefined` for Truffle's solidity tests here.
     if (contractAddress) {
-      return ethers.utils.hexStripZeros(contractAddress);
+      contractAddress = ethers.utils.hexStripZeros(contractAddress);
+      contractName = this.data.getNameByAddress(contractAddress);
+
+      // Try to resolve by deployedBytecode
+      if (!contractName) {
+        const code = this.sync.getCode(contractAddress);
+        const match = this.data.getContractByDeployedBytecode(code);
+
+        if (match) {
+          contractName = match.name;
+          this.data.trackNameByAddress(match.name, contractAddress);
+        }
+      }
+      return contractName;
     }
   }
 }

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -14,7 +14,7 @@ class ProxyResolver {
     } else if (config.proxyResolver === "ZOS@2") {
       this.resolve = this._zos2;
     } else {
-      this.resolve = this.firstMatch;
+      this.resolve = this.resolveByMethodSignature;
     }
   }
 
@@ -24,11 +24,29 @@ class ProxyResolver {
    * @param  {Object} transaction result of web3.eth.getTransaction
    * @return {String}             contract name
    */
-  firstMatch(transaction) {
+  resolveByMethodSignature(transaction) {
     const signature = transaction.input.slice(2, 10);
     const matches = this.data.getAllContractsWithMethod(signature);
 
     if (matches.length >= 1) return matches[0].contract;
+  }
+
+  /**
+   * Tries to match bytecode deployed at address to deployedBytecode listed
+   * in artifacts. If found, adds this to the code-hash name mapping and
+   * returns name.
+   * @param  {String} address contract address
+   * @return {String}         contract name
+   */
+  resolveByDeployedBytecode(address) {
+    const code = this.sync.getCode(address);
+    const match = this.data.getContractByDeployedBytecode(code);
+
+    if (match) {
+      this.data.trackNameByAddress(match.name, address);
+      console.log("resolving by deployedBytecode: " + match.name);
+      return match.name;
+    }
   }
 
   /**
@@ -75,16 +93,8 @@ class ProxyResolver {
       contractName = this.data.getNameByAddress(contractAddress);
 
       // Try to resolve by deployedBytecode
-      if (!contractName) {
-        const code = this.sync.getCode(contractAddress);
-        const match = this.data.getContractByDeployedBytecode(code);
-
-        if (match) {
-          contractName = match.name;
-          this.data.trackNameByAddress(match.name, contractAddress);
-        }
-      }
-      return contractName;
+      if (contractName) return contractName;
+      else return this.resolveByDeployedBytecode(contractAddress);
     }
   }
 }

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -44,7 +44,6 @@ class ProxyResolver {
 
     if (match) {
       this.data.trackNameByAddress(match.name, address);
-      console.log("resolving by deployedBytecode: " + match.name);
       return match.name;
     }
   }

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -1,0 +1,77 @@
+const ethers = require("ethers");
+const SyncRequest = require("./syncRequest");
+
+class ProxyResolver {
+  constructor(data, config) {
+    this.unresolvedCalls = 0;
+    this.data = data;
+    this.sync = new SyncRequest(config.url);
+
+    if (typeof config.proxyResolver === "function") {
+      this.resolve = config.proxyResolver.bind(this);
+    } else if (config.proxyResolver === "EtherRouter") {
+      console.log("attaching to _etherRouter");
+      this.resolve = this._etherRouter;
+    } else if (config.proxyResolver === "ZOS@2") {
+      this.resolve = this._zos2;
+    } else {
+      this.resolve = this._default;
+    }
+  }
+
+  /**
+   * Searches all known contracts for the method signature and returns the first
+   * found (if any). Undefined if none
+   * @param  {Object} transaction result of web3.eth.getTransaction
+   * @return {String}             contract name
+   */
+  _default(transaction) {
+    const signature = transaction.input.slice(2, 10);
+    const matches = this.data.getAllContractsWithMethod(signature);
+
+    if (matches.length >= 1) return matches[0].contract;
+  }
+
+  /**
+   * Queries EtherRouter for address of resolver.
+   * Queries Resolver for contract address w/ method signature.
+   * Returns contract name matching the resolved address.
+   * @param  {Object} transaction result of web3.eth.getTransaction
+   * @return {String}             contract name
+   */
+  _etherRouter(transaction) {
+    let contractAddress;
+    try {
+      const ABI = ["function resolver()", "function lookup(bytes4 sig)"];
+
+      const iface = new ethers.utils.Interface(ABI);
+      const signature = transaction.input.slice(0, 10);
+
+      // EtherRouter.resolver
+      const resolverAddress = this.sync.call(
+        {
+          to: transaction.to,
+          data: iface.functions.resolver.encode([])
+        },
+        transaction.blockNumber
+      );
+
+      // Resolver.lookup(sig)
+      contractAddress = this.sync.call(
+        {
+          to: ethers.utils.hexStripZeros(resolverAddress),
+          data: iface.functions.lookup.encode([signature])
+        },
+        transaction.blockNumber
+      );
+    } catch (err) {
+      this.unresolvedCalls++;
+      return this._default(transaction);
+    }
+
+    contractAddress = ethers.utils.hexStripZeros(contractAddress);
+    return this.data.getNameByAddress(contractAddress);
+  }
+}
+
+module.exports = ProxyResolver;

--- a/lib/syncRequest.js
+++ b/lib/syncRequest.js
@@ -43,6 +43,10 @@ class Sync {
     return this.request("eth_getTransactionReceipt", [tx]);
   }
 
+  call(payload, blockNumber) {
+    return this.request("eth_call", [payload, blockNumber]);
+  }
+
   request(method, params) {
     const payload = {
       json: {

--- a/lib/transactionWatcher.js
+++ b/lib/transactionWatcher.js
@@ -73,32 +73,18 @@ class TransactionWatcher {
    * @param  {Object} receipt
    */
   _collectMethodsData(transaction, receipt) {
-    let address;
     let contractName = this.data.getNameByAddress(transaction.to);
 
     // Case: proxied call
     // We have a known contract-name-to-address match & an unknown method ID
     if (this._isProxied(contractName, transaction.input)) {
-      contractName = null;
-      address = this.resolver.resolve(transaction);
-
-      // Try to match address to known deployment & default to
-      // the transaction address if resolver failed.
-      address
-        ? (contractName = this.data.getNameByAddress(address))
-        : (address = transaction.to);
+      contractName = this.resolver.resolve(transaction);
     }
 
-    // Case: unknown contract address
-    // Try to create a new deployment record
+    // Case: unknown contract address, (possibly dropped through from proxy)
+    // Use first match strategy
     if (!contractName) {
-      const code = this.sync.getCode(address);
-      const match = this.data.getContractByDeploymentInput(code);
-
-      if (match) {
-        contractName = match.name;
-        this.data.trackNameByAddress(match.name, address);
-      }
+      contractName = this.resolver.firstMatch(transaction);
     }
 
     const id = utils.getMethodID(contractName, transaction.input);

--- a/lib/transactionWatcher.js
+++ b/lib/transactionWatcher.js
@@ -1,6 +1,7 @@
 const utils = require("./utils");
 const GasData = require("./gasData");
 const SyncRequest = require("./syncRequest");
+const ProxyResolver = require("./proxyResolver");
 
 /**
  * Tracks blocks and cycles across them, extracting gas usage data and
@@ -12,6 +13,7 @@ class TransactionWatcher {
     this.beforeStartBlock = 0; // Tracks from `before/beforeEach` transactions (methods & deploys)
     this.data = new GasData();
     this.sync = new SyncRequest(config.url);
+    this.resolver = new ProxyResolver(this.data, config);
   }
 
   /**
@@ -74,20 +76,15 @@ class TransactionWatcher {
     let isProxied = false;
     let contractName = this.data.getNameByAddress(transaction.to);
 
+    // Detect proxied transaction
     if (contractName) {
       let candidateId = utils.getMethodID(contractName, transaction.input);
       isProxied = !this.data.methods[candidateId];
     }
 
-    // If unfound, search by method signature alone. These often shadow
-    // each other so this is isn't accurate.
+    // Resolve proxied transaction
     if (!contractName || isProxied) {
-      const signature = transaction.input.slice(2, 10);
-      const matches = this.data.getAllContractsWithMethod(signature);
-
-      if (matches.length >= 1) {
-        contractName = matches[0].contract;
-      }
+      contractName = this.resolver.resolve(transaction);
     }
 
     const id = utils.getMethodID(contractName, transaction.input);
@@ -95,6 +92,8 @@ class TransactionWatcher {
     if (this.data.methods[id]) {
       this.data.methods[id].gasData.push(utils.gas(receipt.gasUsed));
       this.data.methods[id].numberOfCalls++;
+    } else {
+      this.resolver.unresolvedCalls++;
     }
   }
 }

--- a/lib/transactionWatcher.js
+++ b/lib/transactionWatcher.js
@@ -73,18 +73,32 @@ class TransactionWatcher {
    * @param  {Object} receipt
    */
   _collectMethodsData(transaction, receipt) {
-    let isProxied = false;
+    let address;
     let contractName = this.data.getNameByAddress(transaction.to);
 
-    // Detect proxied transaction
-    if (contractName) {
-      let candidateId = utils.getMethodID(contractName, transaction.input);
-      isProxied = !this.data.methods[candidateId];
+    // Case: proxied call
+    // We have a known contract-name-to-address match & an unknown method ID
+    if (this._isProxied(contractName, transaction.input)) {
+      contractName = null;
+      address = this.resolver.resolve(transaction);
+
+      // Try to match address to known deployment & default to
+      // the transaction address if resolver failed.
+      address
+        ? (contractName = this.data.getNameByAddress(address))
+        : (address = transaction.to);
     }
 
-    // Resolve proxied transaction
-    if (!contractName || isProxied) {
-      contractName = this.resolver.resolve(transaction);
+    // Case: unknown contract address
+    // Try to create a new deployment record
+    if (!contractName) {
+      const code = this.sync.getCode(address);
+      const match = this.data.getContractByDeploymentInput(code);
+
+      if (match) {
+        contractName = match.name;
+        this.data.trackNameByAddress(match.name, address);
+      }
     }
 
     const id = utils.getMethodID(contractName, transaction.input);
@@ -95,6 +109,17 @@ class TransactionWatcher {
     } else {
       this.resolver.unresolvedCalls++;
     }
+  }
+
+  /**
+   * Returns true if there is a contract name associated with an address
+   * but method can't be matched to it
+   * @param  {String}  name  contract name
+   * @param  {String}  input code
+   * @return {Boolean}
+   */
+  _isProxied(name, input) {
+    return name && !this.data.methods[utils.getMethodID(name, input)];
   }
 }
 

--- a/lib/transactionWatcher.js
+++ b/lib/transactionWatcher.js
@@ -76,15 +76,17 @@ class TransactionWatcher {
     let contractName = this.data.getNameByAddress(transaction.to);
 
     // Case: proxied call
-    // We have a known contract-name-to-address match & an unknown method ID
     if (this._isProxied(contractName, transaction.input)) {
       contractName = this.resolver.resolve(transaction);
+
+      // Case: hidden contract factory deployment
+    } else if (!contractName) {
+      contractName = this.resolver.resolveByDeployedBytecode(transaction.to);
     }
 
-    // Case: unknown contract address, (possibly dropped through from proxy)
-    // Use first match strategy
+    // Case: all else fails, use first match strategy
     if (!contractName) {
-      contractName = this.resolver.firstMatch(transaction);
+      contractName = this.resolver.resolveByMethodSignature(transaction);
     }
 
     const id = utils.getMethodID(contractName, transaction.input);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,7 @@ const utils = {
    * @param  {String} bytecode
    * @return {String}
    */
-  bytecodeToBytecodeRegex: function(bytecode) {
+  bytecodeToBytecodeRegex: function(bytecode = "") {
     const bytecodeRegex = bytecode
       .replace(/__.{38}/g, ".{40}")
       .replace(/73f{40}/g, ".{42}");

--- a/mock/config-template.js
+++ b/mock/config-template.js
@@ -1,23 +1,24 @@
 module.exports = {
   networks: {
     development: {
-      host: 'localhost',
+      host: "localhost",
       port: 8545,
-      network_id: '*',
-      websockets: (process.env.TEST === 'integration') ? true : false
+      network_id: "*",
+      websockets: process.env.TEST === "integration" ? true : false
     }
   },
   mocha: {
-    reporter: 'eth-gas-reporter',
+    reporter: "eth-gas-reporter",
     reporterOptions: {
       currency: "chf",
       gasPrice: 21,
       onlyCalledMethods: false,
       noColors: true,
       rst: true,
-      rstTitle: 'Gas Usage',
+      rstTitle: "Gas Usage",
       showTimeSpent: true,
-      excludeContracts: ['Migrations'],
+      excludeContracts: ["Migrations"],
+      proxyResolver: "EtherRouter"
     }
   }
-}
+};

--- a/mock/contracts/EtherRouter/EtherRouter.sol
+++ b/mock/contracts/EtherRouter/EtherRouter.sol
@@ -1,0 +1,64 @@
+/*
+  This file is part of The Colony Network.
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity ^0.5.0;
+
+import "./Resolver.sol";
+
+contract EtherRouter {
+  Resolver public resolver;
+
+  function() external payable {
+    if (msg.sig == 0) {
+      return;
+    }
+    // Contracts that want to receive Ether with a plain "send" have to implement
+    // a fallback function with the payable modifier. Contracts now throw if no payable
+    // fallback function is defined and no function matches the signature.
+    // However, 'send' only provides 2300 gas, which is not enough for EtherRouter
+    // so we shortcut it here.
+    //
+    // Note that this means we can never have a fallback function that 'does' stuff.
+    // but those only really seem to be ICOs, to date. To be explicit, there is a hard
+    // decision to be made here. Either:
+    // 1. Contracts that use 'send' or 'transfer' cannot send money to Colonies/ColonyNetwork
+    // 2. We commit to never using a fallback function that does anything.
+    //
+    // We have decided on option 2 here. In the future, if we wish to have such a fallback function
+    // for a Colony, it could be in a separate extension contract.
+
+    // Get routing information for the called function
+    address destination = resolver.lookup(msg.sig);
+
+    // Make the call
+    assembly {
+      let size := extcodesize(destination)
+      if eq(size, 0) { revert(0,0) }
+
+      calldatacopy(mload(0x40), 0, calldatasize)
+      let result := delegatecall(gas, destination, mload(0x40), calldatasize, mload(0x40), 0) // ignore-swc-112 calls are only to trusted contracts
+      // as their addresses are controlled by the Resolver which we trust
+      returndatacopy(mload(0x40), 0, returndatasize)
+      switch result
+      case 1 { return(mload(0x40), returndatasize) } // ignore-swc-113
+      default { revert(mload(0x40), returndatasize) }
+    }
+  }
+
+  function setResolver(address _resolver) public
+  {
+    resolver = Resolver(_resolver);
+  }
+}
+

--- a/mock/contracts/EtherRouter/Factory.sol
+++ b/mock/contracts/EtherRouter/Factory.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.0;
+
+import "./VersionA.sol";
+import "./VersionB.sol";
+
+contract Factory {
+
+  VersionA public versionA;
+  VersionB public versionB;
+
+  constructor() public {
+  }
+
+  function deployVersionA() public {
+    versionA = new VersionA();
+  }
+
+  function deployVersionB() public {
+    versionB = new VersionB();
+  }
+}

--- a/mock/contracts/EtherRouter/Resolver.sol
+++ b/mock/contracts/EtherRouter/Resolver.sol
@@ -1,0 +1,32 @@
+/*
+  This file is part of The Colony Network.
+  The Colony Network is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  The Colony Network is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with The Colony Network. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+pragma solidity ^0.5.0;
+
+contract Resolver {
+  mapping (bytes4 => address) public pointers;
+
+  function register(string memory signature, address destination) public
+  {
+    pointers[stringToSig(signature)] = destination;
+  }
+
+  function lookup(bytes4 sig) public view returns(address) {
+    return pointers[sig];
+  }
+
+  function stringToSig(string memory signature) public pure returns(bytes4) {
+    return bytes4(keccak256(abi.encodePacked(signature)));
+  }
+}

--- a/mock/contracts/EtherRouter/VersionA.sol
+++ b/mock/contracts/EtherRouter/VersionA.sol
@@ -1,14 +1,10 @@
 pragma solidity ^0.5.0;
 
 contract VersionA {
-
-  uint value;
-
   constructor() public {
   }
 
-  function setValue(uint val) public {
-    value = val;
+  function setValue() public {
   }
 
 }

--- a/mock/contracts/EtherRouter/VersionA.sol
+++ b/mock/contracts/EtherRouter/VersionA.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.5.0;
+
+contract VersionA {
+
+  uint value;
+
+  constructor() public {
+  }
+
+  function setValue(uint val) public {
+    value = val;
+  }
+
+}

--- a/mock/contracts/EtherRouter/VersionB.sol
+++ b/mock/contracts/EtherRouter/VersionB.sol
@@ -7,4 +7,7 @@ contract VersionB {
 
   function setValue() public {
   }
+
+  function setAnotherValue() public {
+  }
 }

--- a/mock/contracts/EtherRouter/VersionB.sol
+++ b/mock/contracts/EtherRouter/VersionB.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+contract VersionB {
+
+  uint value;
+  uint counter;
+
+  constructor() public{
+  }
+
+  function setValue(uint val) public {
+    value = val;
+    counter = counter + 1;
+  }
+}

--- a/mock/contracts/EtherRouter/VersionB.sol
+++ b/mock/contracts/EtherRouter/VersionB.sol
@@ -2,14 +2,9 @@ pragma solidity ^0.5.0;
 
 contract VersionB {
 
-  uint value;
-  uint counter;
-
   constructor() public{
   }
 
-  function setValue(uint val) public {
-    value = val;
-    counter = counter + 1;
+  function setValue() public {
   }
 }

--- a/mock/package.json
+++ b/mock/package.json
@@ -54,7 +54,7 @@
     "husky": "^2.3.0",
     "prettier": "1.17.1",
     "pretty-quick": "^1.11.0",
-    "truffle": "5.0.15",
+    "truffle": "5.0.12",
     "web3": "1.0.0-beta.37",
     "yarn": "^1.16.0"
   }

--- a/mock/package.json
+++ b/mock/package.json
@@ -8,6 +8,11 @@
     "test": "./mock/scripts/test.sh",
     "ci": "./scripts/ci.sh"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cgewecke/eth-gas-reporter.git"
@@ -29,6 +34,7 @@
     "abi-decoder": "^1.2.0",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
+    "ethers": "^4.0.28",
     "lodash": "^4.17.11",
     "mocha": "^4.1.0",
     "req-cwd": "^2.0.0",
@@ -45,7 +51,9 @@
     "@nomiclabs/buidler-web3": "^1.0.0-beta.7",
     "ganache-cli": "6.4.3",
     "geth-dev-assistant": "^0.0.3",
+    "husky": "^2.3.0",
     "prettier": "1.17.1",
+    "pretty-quick": "^1.11.0",
     "truffle": "5.0.15",
     "web3": "1.0.0-beta.37",
     "yarn": "^1.16.0"

--- a/mock/scripts/test.sh
+++ b/mock/scripts/test.sh
@@ -24,5 +24,5 @@ sleep 5
 # -----------------------  Install Reporter and run tests ------------------------------------------
 install_reporter
 test_truffle_v5_basic
-#test_truffle_v5_with_options
-#test_buildler_v5_plugin
+test_truffle_v5_with_options
+test_buildler_v5_plugin

--- a/mock/scripts/test.sh
+++ b/mock/scripts/test.sh
@@ -24,5 +24,5 @@ sleep 5
 # -----------------------  Install Reporter and run tests ------------------------------------------
 install_reporter
 test_truffle_v5_basic
-test_truffle_v5_with_options
-test_buildler_v5_plugin
+#test_truffle_v5_with_options
+#test_buildler_v5_plugin

--- a/mock/test/etherrouter.js
+++ b/mock/test/etherrouter.js
@@ -9,14 +9,29 @@ contract("EtherRouter Proxy", accounts => {
   let versionA;
   let versionB;
 
-  before(async function() {
+  beforeEach(async function() {
     router = await EtherRouter.new();
-    resolver = await resolver.new();
-    versionA = await versionA.new();
-    versionB = await versionB.new();
+    resolver = await Resolver.new();
+    versionA = await VersionA.new();
+    versionB = await VersionB.new();
   });
 
-  it("Disambiguates methods routed through a proxy", async function() {
+  it("Resolves methods routed through an EtherRouter proxy", async function() {
+    let options = {
+      from: accounts[0],
+      gas: 4000000,
+      to: router.address,
+      gasPrice: 20000000000
+    };
+
     await router.setResolver(resolver.address);
+
+    await resolver.register("setValue()", versionA.address);
+    options.data = versionA.contract.methods.setValue().encodeABI();
+    await web3.eth.sendTransaction(options);
+
+    await resolver.register("setValue()", versionB.address);
+    options.data = versionB.contract.methods.setValue().encodeABI();
+    await web3.eth.sendTransaction(options);
   });
 });

--- a/mock/test/etherrouter.js
+++ b/mock/test/etherrouter.js
@@ -1,0 +1,22 @@
+const EtherRouter = artifacts.require("EtherRouter");
+const Resolver = artifacts.require("Resolver");
+const VersionA = artifacts.require("VersionA");
+const VersionB = artifacts.require("VersionB");
+
+contract("EtherRouter Proxy", accounts => {
+  let router;
+  let resolver;
+  let versionA;
+  let versionB;
+
+  before(async function() {
+    router = await EtherRouter.new();
+    resolver = await resolver.new();
+    versionA = await versionA.new();
+    versionB = await versionB.new();
+  });
+
+  it("Disambiguates methods routed through a proxy", async function() {
+    await router.setResolver(resolver.address);
+  });
+});

--- a/mock/test/etherrouter.js
+++ b/mock/test/etherrouter.js
@@ -1,19 +1,26 @@
 const EtherRouter = artifacts.require("EtherRouter");
 const Resolver = artifacts.require("Resolver");
+const Factory = artifacts.require("Factory");
 const VersionA = artifacts.require("VersionA");
 const VersionB = artifacts.require("VersionB");
 
 contract("EtherRouter Proxy", accounts => {
   let router;
   let resolver;
+  let factory;
   let versionA;
   let versionB;
 
   beforeEach(async function() {
     router = await EtherRouter.new();
     resolver = await Resolver.new();
+    factory = await Factory.new();
     versionA = await VersionA.new();
-    versionB = await VersionB.new();
+
+    // Emulate internal deployment
+    await factory.deployVersionB();
+    const versionBAddress = await factory.versionB();
+    versionB = await VersionB.at(versionBAddress);
   });
 
   it("Resolves methods routed through an EtherRouter proxy", async function() {

--- a/mock/truffle.js
+++ b/mock/truffle.js
@@ -1,12 +1,12 @@
 module.exports = {
   networks: {
     development: {
-      host: 'localhost',
+      host: "localhost",
       port: 8545,
-      network_id: '*' // Match any network id
+      network_id: "*" // Match any network id
     }
   },
   mocha: {
-    reporter: 'eth-gas-reporter',
+    reporter: "eth-gas-reporter"
   }
-}
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -303,8 +303,7 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-      "dev": true
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
     },
     "ajv": {
       "version": "6.10.0",
@@ -546,8 +545,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -596,8 +594,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -1620,10 +1617,9 @@
       }
     },
     "ethers": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
-      "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
-      "dev": true,
+      "version": "4.0.28",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.28.tgz",
+      "integrity": "sha512-5JTHrPoFLqf+xCAI3pKwXSOgWBSJJoAUdPtPLr1ZlKbSKiIFMkPlRNovmZS3jhIw5sHW1YoVWOaJ6ZR2gKRbwg==",
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -1631,7 +1627,7 @@
         "elliptic": "6.3.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
-        "scrypt-js": "2.0.3",
+        "scrypt-js": "2.0.4",
         "setimmediate": "1.0.4",
         "uuid": "2.0.1",
         "xmlhttprequest": "1.8.0"
@@ -1641,7 +1637,6 @@
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
           "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -1653,7 +1648,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -1662,20 +1656,17 @@
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
         },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -6934,8 +6925,7 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
@@ -7864,10 +7854,9 @@
       }
     },
     "scrypt-js": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
-      "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-      "dev": true
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "scrypt.js": {
       "version": "0.2.0",
@@ -9117,6 +9106,72 @@
         "ethers": "4.0.0-beta.1",
         "underscore": "1.8.3",
         "web3-utils": "1.0.0-beta.37"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "6.3.3",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+          "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "ethers": {
+          "version": "4.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.1.tgz",
+          "integrity": "sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+          "dev": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        }
       }
     },
     "web3-eth-accounts": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8595,9 +8595,9 @@
       }
     },
     "truffle": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.15.tgz",
-      "integrity": "sha512-/FAabG/+xv4mADQvm4YXTMWThXrc9Z4MsMCqWixrd6DlQMPBQIV5F86DeYHgkKbp8hRM3oGUdBVfpWRaha6YKg==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.12.tgz",
+      "integrity": "sha512-dqnDmtTGNcnL29PHQwPE/CVmFFeGLuTFeb4TS3VY/vbASefu118IKXcadOWzkCPPwktv/njwylHSPhwoS00F2A==",
       "dev": true,
       "requires": {
         "app-module-path": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "husky": "^2.3.0",
     "prettier": "1.17.1",
     "pretty-quick": "^1.11.0",
-    "truffle": "5.0.15",
+    "truffle": "5.0.12",
     "web3": "1.0.0-beta.37",
     "yarn": "^1.16.0"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "abi-decoder": "^1.2.0",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
+    "ethers": "^4.0.28",
     "lodash": "^4.17.11",
     "mocha": "^4.1.0",
     "req-cwd": "^2.0.0",


### PR DESCRIPTION
- [x] Add option to do additional address resolution if method id can't be matched to `tx.to` address
- [x] Add built-in support for EtherRouter (and test)

[Edit - Despite all this, there's no change in the Colony output because the 'first guess' strategy happens upon the same contract names. ]

These will go in separate PRs:
+ test for arbitrary resolver function 
+ built-in support for ZOS lib upgradeability (and test) 