### PR TITLE
Allow buidler plugin to manage configuration

### DIFF
--- a/lib/artifactor.js
+++ b/lib/artifactor.js
@@ -6,18 +6,12 @@ const SyncRequest = require("./syncRequest");
  * ```
  * const artifactor = new Artifactor(config);
  * const contract = artifactor.require('Example');
- * {
- *   abi: [etc...],
- *   bytecode: "0x" + contract.evm.bytecode.object,                // (solc key name)
- *   deployedBytecode: "0x" + contract.evm.deployedBytecode.object // (solc key name)
  *
- *   // Optional - pre-test contract deployments  e.g from `truffle migrate`
- *   // TODO: We don't need the address if we have the tx hash.
- *   deployed: {
- *     address: "0xabc..",
- *     transactionHash: "Oxabc"
- *   }
- * }
+ * > {
+ * >   abi: [etc...],
+ * >   bytecode: "0x" + contract.evm.bytecode.object,                // (solc key name)
+ * >   deployedBytecode: "0x" + contract.evm.deployedBytecode.object // (solc key name)
+ * > }
  */
 class Artifactor {
   constructor(config) {
@@ -37,7 +31,8 @@ class Artifactor {
         return this._truffleArtifactor(contractName);
       case "0xProject-v2":
         return this._0xArtifactor(contractName);
-      case "buidler":
+      case "buidler-v1":
+        return this._buidlerArtifactor(contractName);
       case "ethpm":
       default:
         return this._truffleArtifactor(contractName);
@@ -50,22 +45,13 @@ class Artifactor {
    * @return {Object}              egr artifact
    */
   _truffleArtifactor(contractName) {
-    let metadata = {};
-    let deployedBytecode;
-    const contract = {};
     const artifact = artifacts.require(contractName);
 
-    // Temporary (buidler)
-    try {
-      deployedBytecode = artifact.deployedBytecode;
-      this.config.metadata = JSON.parse(artifact.metadata);
-    } catch (err) {
-      //
-    }
-
-    contract.abi = artifact.abi;
-    contract.bytecode = this._normalizeBytecode(artifact.bytecode);
-    contract.deployedBytecode = this._normalizeBytecode(deployedBytecode);
+    const contract = {
+      abi: artifact.abi,
+      bytecode: artifact.bytecode,
+      deployedBytecode: artifact.deployedBytecode
+    };
 
     const deployed = artifact.networks[this.networkId];
 
@@ -77,9 +63,32 @@ class Artifactor {
       };
     }
 
+    this.config.metadata = JSON.parse(artifact.metadata);
     return contract;
   }
 
+  /**
+   * Buidler artifact translator. Solc info (metadata) is attached to config
+   * at the buidler plugin
+   * @param  {String} contractName
+   * @return {Object}              egr artifact
+   */
+  _buidlerArtifactor(contractName) {
+    const artifact = artifacts.require(contractName);
+
+    const contract = {
+      abi: artifact.abi,
+      bytecode: this._normalizeBytecode(artifact.bytecode)
+    };
+
+    return contract;
+  }
+
+  /**
+   * 0x artifact translator. Untested stub.
+   * @param  {String} contractName
+   * @return {Object}              egr artifact
+   */
   _0xArtifactor(contractName) {
     const contract = {};
     const artifact = require(`./artifacts/${contractName}.json`);

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,7 @@ class Config {
     this.artifactType = options.artifactType || "truffle-v5";
     this.noColors = options.noColors;
     this.proxyResolver = options.proxyResolver || null;
+    this.metadata = options.metadata || null;
 
     this.excludeContracts = Array.isArray(options.excludeContracts)
       ? options.excludeContracts
@@ -25,16 +26,16 @@ class Config {
 
     this.onlyCalledMethods = options.onlyCalledMethods === false ? false : true;
 
-    this.url = options.url || this.resolveClientUrl(options);
+    this.url = options.url
+      ? this._normalizeUrl(options.url)
+      : this.resolveClientUrl();
   }
 
   /**
-   * Tries to obtain the client url reporter's sync-requests will
-   * target. If url is ws://, http:// must be substituted.
-   * @param  {Object} options mocha's reporterOptions
+   * Tries to obtain the client url reporter's sync-requests will target.
    * @return {String}         url e.g http://localhost:8545
    */
-  resolveClientUrl(options) {
+  resolveClientUrl() {
     // Case: web3 globally available in mocha test context
     try {
       if (web3 && web3.currentProvider) {
@@ -44,13 +45,7 @@ class Config {
         if (cp.host) return cp.host;
 
         // Truffle/Web3 websockets
-        if (cp.connection) return cp.connection.url.replace("ws://", "http://");
-
-        // Buildler web3 plugin
-        // Per #116 another possibility is
-        // `config.networks[buidlerArguments.network].url`
-        if (cp._provider && cp._provider.provider && cp._provider.provider.host)
-          return cp._provider.provider.host;
+        if (cp.connection) return this._normalizeUrl(cp.connection.url);
       }
     } catch (err) {
       // Web3 undefined
@@ -62,8 +57,17 @@ class Config {
       `from the provider available in your test context. Try setting the ` +
       `url as a mocha reporter option (ex: url='http://localhost:8545')`;
 
-    log(message);
+    console.log(message);
     process.exit(1);
+  }
+
+  /**
+   * Forces websockets to http
+   * @param  {String} url e.g web3.provider.connection.url
+   * @return {String}     http:// prefixed url
+   */
+  _normalizeUrl(url) {
+    return url.replace("ws://", "http://");
   }
 }
 

--- a/mock/buidler.config.js
+++ b/mock/buidler.config.js
@@ -9,6 +9,10 @@ module.exports = {
     }
   },
   mocha: {
-    reporter: "eth-gas-reporter"
+    reporter: "eth-gas-reporter",
+    reporterOptions: {
+      artifactType: "buidler-v1",
+      url: "http://localhost:8545"
+    }
   }
 };

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
These changes make it possible for the buidler plugin to pass relevant config info from the BRE to the reporter. 