### PR TITLE
Fix variable name mismatch

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -52,7 +52,7 @@ class Config {
     }
 
     // Case: Failure
-    const msg =
+    const message =
       `ERROR: eth-gas-reporter was unable to resolve a client url ` +
       `from the provider available in your test context. Try setting the ` +
       `url as a mocha reporter option (ex: url='http://localhost:8545')`;


### PR DESCRIPTION
To fix where variable is declared as `msg` but referenced as `message` on the next line