### PR TITLE
Fix crashing when transactionHash is stale

### DIFF
--- a/lib/gasData.js
+++ b/lib/gasData.js
@@ -60,11 +60,13 @@ class GasData {
 
           // Report gas used during pre-test deployments (ex: truffle migrate)
           if (contract.deployed && contract.deployed.transactionHash) {
-            this.trackNameByAddress(name, contract.deployed.address);
             const receipt = this.sync.getTransactionReceipt(
               contract.deployed.transactionHash
             );
-            contractInfo.gasData.push(utils.gas(receipt.gasUsed));
+            if (receipt) {
+              this.trackNameByAddress(name, contract.deployed.address);
+              contractInfo.gasData.push(utils.gas(receipt.gasUsed));
+            }
           }
 
           // Decode, getMethodIDs


### PR DESCRIPTION
* Gas reporter crashes after deleting or disabling previously migrated contracts (issue #194)