### PR TITLE
Stop crashing when parser or ABI Encoder fails

### DIFF
--- a/lib/gasData.js
+++ b/lib/gasData.js
@@ -71,7 +71,14 @@ class GasData {
 
           // Decode, getMethodIDs
           const methodIDs = {};
-          const methods = new ethersABI.Interface(contract.abi).functions;
+
+          let methods;
+          try {
+            methods = new ethersABI.Interface(contract.abi).functions;
+          } catch (err) {
+            utils.warnEthers(name, err);
+            return;
+          }
 
           // Generate sighashes and remap ethers to something similar
           // to abiDecoder.getMethodIDs

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@ const parser = require("solidity-parser-diligence");
 const request = require("request-promise-native");
 const path = require("path");
 const read = require("fs-readdir-recursive");
+const colors = require("colors/safe");
+const log = console.log;
 
 const utils = {
   /**
@@ -94,7 +96,14 @@ const utils = {
   getContractNames: function(filePath) {
     const names = [];
     const code = fs.readFileSync(filePath, "utf-8");
-    const ast = parser.parse(code, { tolerant: true });
+
+    let ast;
+    try {
+      ast = parser.parse(code, { tolerant: true });
+    } catch (err) {
+      utils.warnParser(filePath, err);
+      return names;
+    }
 
     parser.visit(ast, {
       ContractDefinition: function(node) {
@@ -103,6 +112,50 @@ const utils = {
     });
 
     return names;
+  },
+
+  /**
+   * Message for un-parseable files
+   * @param  {String} filePath
+   * @param  {Error} err
+   * @return {void}
+   */
+  warnParser: function(filePath, err) {
+    log();
+    log(colors.red(`>>>>> WARNING <<<<<<`));
+    log(
+      `Failed to parse file: "${filePath}". No data will collected for its contract(s).`
+    );
+    log(
+      `NB: some Solidity 0.6.x syntax is not supported by the JS parser yet.`
+    );
+    log(
+      `Please report the error below to github.com/consensys/solidity-parser-antlr`
+    );
+    log(colors.red(`>>>>>>>>>>>>>>>>>>>>`));
+    log(colors.red(`${err}`));
+    log();
+  },
+
+  /**
+   * Message for un-parseable ABI (ethers)
+   * @param  {String} name contract name
+   * @param  {Error} err
+   * @return {void}
+   */
+  warnEthers: function(name, err) {
+    log();
+    log(colors.red(`>>>>> WARNING <<<<<<`));
+    log(
+      `Failed to parse ABI for contract: "${name}". (Its method data will not be collected).`
+    );
+    log(
+      `NB: Some Solidity 0.6.x syntax is not supported by Ethers.js V5 AbiCoder yet.`
+    );
+    log(`Please report the error below to github.com/ethers-io/ethers.js`);
+    log(colors.red(`>>>>>>>>>>>>>>>>>>>>`));
+    log(colors.red(`${err}`));
+    log();
   },
 
   /**

--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "@codechecks/client": "^0.1.0"
   },
   "dependencies": {
-    "@ethersproject/abi": "5.0.0-beta.142",
+    "@ethersproject/abi": "^5.0.0-beta.146",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
     "ethereumjs-util": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,9 +125,9 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.0-beta.142",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.142.tgz",
-      "integrity": "sha512-vJ2V9fPNzi+8iutY4sjy6mgogkJtiGsd9hmpa1bjnGW6qnHOEkAV1fzVpvT002LlnjFgqgtzuLBDZob6oU7i8w==",
+      "version": "5.0.0-beta.146",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.146.tgz",
+      "integrity": "sha512-9wn60tZ0rLGTlHnrD2V58i+bo+UvWytSCuI506ytqfwYauPI9gSkd3IPQI8Li61J1albZa4qtM37W5QlP0B7Eg==",
       "requires": {
         "@ethersproject/address": ">=5.0.0-beta.128",
         "@ethersproject/bignumber": ">=5.0.0-beta.130",
@@ -141,9 +141,9 @@
       }
     },
     "@ethersproject/address": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.133.tgz",
-      "integrity": "sha512-7SjGhZ3xClqlmzqNNzESKlHbBeEzDWXIeKUBbSzK3Ce9PgK6uboiNe53fgqzhrRVOMhD1J4Q+oIm4DsTv37FWg==",
+      "version": "5.0.0-beta.134",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.0-beta.134.tgz",
+      "integrity": "sha512-FHhUVJTUIg2pXvOOhIt8sB1cQbcwrzZKzf9CPV7JM1auli20nGoYhyMFYGK7u++GXzTMJduIkU1OwlIBupewDw==",
       "requires": {
         "@ethersproject/bignumber": ">=5.0.0-beta.130",
         "@ethersproject/bytes": ">=5.0.0-beta.129",
@@ -165,17 +165,17 @@
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.0.0-beta.134",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.134.tgz",
-      "integrity": "sha512-2BULy5x0BuHPRzuGjEYWndJieDaRAaZUbMk53fZjH4yjhKMHDGADQQOtaSD4wN+H183YOXMGdtlCrRGJ1N+uNg==",
+      "version": "5.0.0-beta.136",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.0-beta.136.tgz",
+      "integrity": "sha512-yoi5Ul16ScMHVNsf+oCDGaAnj+rtXxITcneXPeDl8h0rk1VNIqb1WKKvooD5WtM0oAglyauuDahHIF+4+5G/Sg==",
       "requires": {
         "@ethersproject/logger": ">=5.0.0-beta.129"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.0-beta.132",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.132.tgz",
-      "integrity": "sha512-ioO7Ez8Xatk5z3lVzzEhRjXng1le1sTzfuD3v8gUozrzgLXyl0X81Go1Nadj7qPgo68HziIFcm5kRFp4SdJa0A==",
+      "version": "5.0.0-beta.133",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.0-beta.133.tgz",
+      "integrity": "sha512-VCTpk3AF00mlWQw1vg+fI6qCo0qO5EVWK574t4HNBKW6X748jc9UJPryKUz9JgZ64ZQupyLM92wHilsG/YTpNQ==",
       "requires": {
         "@ethersproject/bignumber": ">=5.0.0-beta.130"
       }
@@ -208,14 +208,14 @@
       }
     },
     "@ethersproject/logger": {
-      "version": "5.0.0-beta.133",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.133.tgz",
-      "integrity": "sha512-1ISf7rFKFbMHlEB37JS7Oy3FgFlvzF2Ze2uFZMJHGKp9xgDvFy1VHNMBM1KrJPK4AqCZXww0//e2keLsN3g/Cw=="
+      "version": "5.0.0-beta.135",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.0-beta.135.tgz",
+      "integrity": "sha512-8Umim0a4lLqHLhoftxRma8ADDTUC5QIP4FvdXps4QJQy6wN4IYmHJffxfNDvGY3DFqwLxftYJobHjsfNOTVRUg=="
     },
     "@ethersproject/properties": {
-      "version": "5.0.0-beta.135",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.135.tgz",
-      "integrity": "sha512-R4ROFaFh86n09eE+MWMPzaB87V5OSgqu0gtQ7LjUvkFF3eqdpdvLVD4N93hvCKNZcjGHI4WmazDUlpuXZVgDkA==",
+      "version": "5.0.0-beta.137",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.0-beta.137.tgz",
+      "integrity": "sha512-AcvoVmV0aXixa7SxaPj237OAIEXl/UMJf4vl2yFNzWjf77mMyZaZoKLLOh2zes++mLeQ3EJEIebSWFm06L5NuA==",
       "requires": {
         "@ethersproject/logger": ">=5.0.0-beta.129"
       }
@@ -229,9 +229,9 @@
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.0-beta.135",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.135.tgz",
-      "integrity": "sha512-MiZSJPhAQggXb3XA/XS4jmwmj5CsknMXk/XIzNZB7eYqEGA2i7sQV7+o6DOE+3lq5k5BhB8OaDziogNCOGAouA==",
+      "version": "5.0.0-beta.136",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.0-beta.136.tgz",
+      "integrity": "sha512-Hb9RvTrgGcOavHvtQZz+AuijB79BO3g1cfF2MeMfCU9ID4j3mbZv/olzDMS2pK9r4aERJpAS94AmlWzCgoY2LQ==",
       "requires": {
         "@ethersproject/bytes": ">=5.0.0-beta.129",
         "@ethersproject/constants": ">=5.0.0-beta.128",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@codechecks/client": "^0.1.0"
   },
   "dependencies": {
-    "@ethersproject/abi": "5.0.0-beta.142",
+    "@ethersproject/abi": "^5.0.0-beta.146",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
     "ethereumjs-util": "6.2.0",


### PR DESCRIPTION
#201 

Solc 0.6.x syntax continues to error the parser (and ethers). 

PR
+ unpins ethers so their fix will auto propagate
+  catches and warns in these cases instead of crashing...