### PR TITLE
Do not try to JSON.stringify provider object (OOM)

### DIFF
--- a/lib/gasTable.js
+++ b/lib/gasTable.js
@@ -275,6 +275,9 @@ class GasTable {
    * @param  {Object} info  GasData instance
    */
   saveCodeChecksData(info) {
+    delete this.config.provider;
+    delete info.provider;
+
     const output = {
       namespace: "ethGasReporter",
       config: this.config,


### PR DESCRIPTION
When CI is true, we write GasData and Config to file as an object so it's available for further analysis. 

The Builder provider attached to those classes in [buidler-gas-reporter 18][1] doesn't serialize. 

[1]: https://github.com/cgewecke/buidler-gas-reporter/pull/18 