### PR TITLE
Update solidity-parser/parser to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.0.0-beta.146",
-    "@solidity-parser/parser": "^0.5.2",
+    "@solidity-parser/parser": "^0.8.0",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
     "ethereumjs-util": "6.2.0",


### PR DESCRIPTION
To support Solidity v0.7.x
This fixes constructors visibility (no public/internal keyword) incompatibility.