### PR TITLE
Revert parser update (due to Node >= 14 req)

### DIFF
--- a/mock/package.json
+++ b/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-gas-reporter",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Mocha reporter which shows gas used per unit test.",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.0.0-beta.146",
-    "@solidity-parser/parser": "^0.8.0",
+    "@solidity-parser/parser": "^0.8.2",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
     "ethereumjs-util": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -625,12 +625,9 @@
       "dev": true
     },
     "@solidity-parser/parser": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.9.1.tgz",
-      "integrity": "sha512-ewNo+ZEQX8mFUOlTK6+0IYvM++6+iEeRBIBg4Mh8ghgRX72bkXJh6AWLWe/SG5+3WPdDL84MSsAlrvWFsGRdFw==",
-      "requires": {
-        "antlr4": "^4.8.0"
-      }
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.2.tgz",
+      "integrity": "sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -1034,11 +1031,6 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true
-    },
-    "antlr4": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.0.tgz",
-      "integrity": "sha512-TAS2RfNblx/wlfy/h0YNaBSC1sg5rQ4Twm0h/ksCoWRAsLo9Freh367zXtRZdKVYSOLkOJbPDJL6TFclCr0Xvw=="
     },
     "any-promise": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "^5.0.0-beta.146",
-    "@solidity-parser/parser": "^0.9.1",
+    "@solidity-parser/parser": "^0.8.2",
     "cli-table3": "^0.5.0",
     "colors": "^1.1.2",
     "ethereumjs-util": "6.2.0",


### PR DESCRIPTION
```
[2/4] 🚚  Fetching packages...
error antlr4@4.9.0: The engine "node" is incompatible with this module. Expected version ">=14". Got "10.15.3"
error Found incompatible module.
```

Node 14 is LTS as of October 27, but this change can't go in a patch release....