### PR TITLE
Make @codechecks/client peer dep optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
   "peerDependencies": {
     "@codechecks/client": "^0.1.0"
   },
+  "peerDependenciesMeta": {
+    "@codechecks/client": {
+      "optional": true
+    },
+  },
   "dependencies": {
     "@ethersproject/abi": "^5.0.0-beta.146",
     "@solidity-parser/parser": "^0.12.0",


### PR DESCRIPTION
this should address cgewecke#229 and prevent yarn/npm from throwing warnings