### PR TITLE
set safe colors dependency version range

### DIFF
--- a/mock/package.json
+++ b/mock/package.json
@@ -42,7 +42,7 @@
     "@ethersproject/abi": "^5.0.0-beta.146",
     "@solidity-parser/parser": "^0.14.0",
     "cli-table3": "^0.5.0",
-    "colors": "^1.1.2",
+    "colors": "1.1.2 - 1.4.0",
     "ethereumjs-util": "6.2.0",
     "ethers": "^4.0.40",
     "fs-readdir-recursive": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ethersproject/abi": "^5.0.0-beta.146",
     "@solidity-parser/parser": "^0.14.0",
     "cli-table3": "^0.5.0",
-    "colors": "^1.1.2",
+    "colors": "1.1.2 - 1.4.0",
     "ethereumjs-util": "6.2.0",
     "ethers": "^4.0.40",
     "fs-readdir-recursive": "^1.1.0",


### PR DESCRIPTION
The `colors` dependency has been attacked by its author.  This change sets the maximum version to `1.4.0`.  In the future it probably makes sense to switch to a new library for color management.