### PR TITLE
Fix: doesn't check contract name, check only method.

### DIFF
--- a/lib/gasTable.js
+++ b/lib/gasTable.js
@@ -73,9 +73,9 @@ class GasTable {
               hAlign: "right",
               content: colors.green(stats.cost.toString())
             });
+            methodRows.push(section);
           }
         }
-        methodRows.push(section);
       }
     });
 

--- a/lib/gasTable.js
+++ b/lib/gasTable.js
@@ -22,6 +22,8 @@ class GasTable {
     // ---------------------------------------------------------------------------------------------
     const methodRows = [];
 
+    const keys = Object.keys(info.codeHashMap);
+    
     _.forEach(info.methods, (data, methodId) => {
       if (!data) return;
 
@@ -58,17 +60,21 @@ class GasTable {
 
       if (!this.config.onlyCalledMethods || data.numberOfCalls > 0) {
         const section = [];
-        section.push(colors.grey(data.contract));
-        section.push(fnName);
-        section.push({ hAlign: "right", content: stats.min });
-        section.push({ hAlign: "right", content: stats.max });
-        section.push({ hAlign: "right", content: stats.average });
-        section.push({ hAlign: "right", content: stats.numberOfCalls });
-        section.push({
-          hAlign: "right",
-          content: colors.green(stats.cost.toString())
-        });
 
+        for (const key of keys) {
+          if (info.codeHashMap[key] == data.contract) {;
+            section.push(colors.grey(data.contract));
+            section.push(fnName);
+            section.push({ hAlign: "right", content: stats.min });
+            section.push({ hAlign: "right", content: stats.max });
+            section.push({ hAlign: "right", content: stats.average });
+            section.push({ hAlign: "right", content: stats.numberOfCalls });
+            section.push({
+              hAlign: "right",
+              content: colors.green(stats.cost.toString())
+            });
+          }
+        }
         methodRows.push(section);
       }
     });

--- a/lib/gasTable.js
+++ b/lib/gasTable.js
@@ -62,7 +62,7 @@ class GasTable {
         const section = [];
 
         for (const key of keys) {
-          if (info.codeHashMap[key] == data.contract) {;
+          if (info.codeHashMap[key] == data.contract) {
             section.push(colors.grey(data.contract));
             section.push(fnName);
             section.push({ hAlign: "right", content: stats.min });

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -21,14 +21,16 @@ class ProxyResolver {
    * Searches all known contracts for the method signature and returns the first
    * found (if any). Undefined if none
    * @param  {Object} transaction result of web3.eth.getTransaction
-   * @return {String}             contract name
+   * @return {String[]}           contract names
    */
   resolveByMethodSignature(transaction) {
     const signature = transaction.input.slice(2, 10);
     const matches = this.data.getAllContractsWithMethod(signature);
 
-    // if (matches.length >= 1) return matches[0].contract;
-    return matches;
+    let result = [];
+    for (const matche of matches) { result.push(matche.contract); }
+
+    return result;
   }
 
   /**

--- a/lib/proxyResolver.js
+++ b/lib/proxyResolver.js
@@ -27,7 +27,8 @@ class ProxyResolver {
     const signature = transaction.input.slice(2, 10);
     const matches = this.data.getAllContractsWithMethod(signature);
 
-    if (matches.length >= 1) return matches[0].contract;
+    // if (matches.length >= 1) return matches[0].contract;
+    return matches;
   }
 
   /**

--- a/lib/transactionWatcher.js
+++ b/lib/transactionWatcher.js
@@ -112,13 +112,22 @@ class TransactionWatcher {
       contractName = this.resolver.resolveByMethodSignature(transaction);
     }
 
-    const id = utils.getMethodID(contractName, transaction.input);
-
-    if (this.data.methods[id]) {
-      this.data.methods[id].gasData.push(utils.gas(receipt.gasUsed));
-      this.data.methods[id].numberOfCalls += 1;
+    let ids = [];
+    if (contractName.length) {
+        for (const cn of contractName) {
+          ids.push(utils.getMethodID(cn, transaction.input));
+        }
     } else {
-      this.resolver.unresolvedCalls++;
+      ids.push(utils.getMethodID(contractName, transaction.input));
+    }
+
+    for (const id of ids) {
+      if (this.data.methods[id]) {
+        this.data.methods[id].gasData.push(utils.gas(receipt.gasUsed));
+        this.data.methods[id].numberOfCalls += 1;
+      } else {
+        this.resolver.unresolvedCalls++;
+      }
     }
   }
 
@@ -147,9 +156,9 @@ class TransactionWatcher {
     }
 
     let ids = [];
-    if(contractName.length) {
+    if (contractName.length) {
         for (const cn of contractName) {
-          ids.push(utils.getMethodID(cn.contract, transaction.input));
+          ids.push(utils.getMethodID(cn, transaction.input));
         }
     } else {
       ids.push(utils.getMethodID(contractName, transaction.input));

--- a/lib/transactionWatcher.js
+++ b/lib/transactionWatcher.js
@@ -146,13 +146,22 @@ class TransactionWatcher {
       contractName = this.resolver.resolveByMethodSignature(transaction);
     }
 
-    const id = utils.getMethodID(contractName, transaction.input);
-
-    if (this.data.methods[id]) {
-      this.data.methods[id].gasData.push(utils.gas(receipt.gasUsed));
-      this.data.methods[id].numberOfCalls += 1;
+    let ids = [];
+    if(contractName.length) {
+        for (const cn of contractName) {
+          ids.push(utils.getMethodID(cn.contract, transaction.input));
+        }
     } else {
-      this.resolver.unresolvedCalls++;
+      ids.push(utils.getMethodID(contractName, transaction.input));
+    }
+    
+    for (const id of ids) {
+      if (this.data.methods[id]) {
+        this.data.methods[id].gasData.push(utils.gas(receipt.gasUsed));
+        this.data.methods[id].numberOfCalls += 1;
+      } else {
+        this.resolver.unresolvedCalls++;
+      }
     }
   }
 


### PR DESCRIPTION
If exist contracts what have same methods, it returns incorrect gas-reporter table.


```
$ ls contracts
// same contract without contract name.
MeToken.sol          MyToken.sol
```

```
describe("gas reporter test.", async() => {
    it("---->", async () => {
        const signer = (await ethers.getSigners())[0];
        const MyToken = await ethers.getContractFactory('MyToken', signer);
       
        const myToken = await upgrades.deployProxy(
            MyToken,
            [ethers.utils.parseEther('1000000'), signer.address],
            { initializer: "init", unsafeAllow: ["delegatecall"]}
        )
        console.log(myToken.address);
        await myToken.print();
    });
});
```

As-is)
![스크린샷 2022-04-20 오후 6 56 11](https://user-images.githubusercontent.com/102017905/164202774-f62ee249-e9a1-4254-92f0-6c4b992f08a0.png)
It's return MeToken report.

Fixed)
![스크린샷 2022-04-20 오후 6 59 40](https://user-images.githubusercontent.com/102017905/164203403-97535371-ddc6-4e88-8c3b-77766cf368d3.png)

