### PR TITLE
Replace deprecated package request-promise-native

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const parser = require("@solidity-parser/parser");
-const request = require("request-promise-native");
+const syncRequest = require("sync-request");
 const path = require("path");
 const read = require("fs-readdir-recursive");
 const colors = require("colors/safe");
@@ -189,8 +189,8 @@ const utils = {
     // Currency market data: coinmarketcap
     if (!config.ethPrice) {
       try {
-        let response = await request.get(currencyPath);
-        response = JSON.parse(response);
+        let response = syncRequest("GET", currencyPath);
+        response = JSON.parse(response.getBody("utf8"));
         config.ethPrice = response.data[token].quote[currencyKey].price.toFixed(
           2
         );
@@ -202,8 +202,8 @@ const utils = {
     // Gas price data: etherscan (or `gasPriceAPI`)
     if (!config.gasPrice) {
       try {
-        let response = await request.get(gasPriceApi);
-        response = JSON.parse(response);
+        let response = syncRequest("GET", gasPriceApi);
+        response = JSON.parse(response.getBody("utf8"));
         config.gasPrice = Math.round(
           parseInt(response.result, 16) / Math.pow(10, 9)
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "mocha": "^10.2.0",
         "req-cwd": "^2.0.0",
         "request": "^2.88.0",
-        "request-promise-native": "^1.0.5",
         "sha1": "^1.1.1",
         "sync-request": "^6.0.0"
       },
@@ -9415,28 +9414,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
       "dependencies": {
         "lodash": "^4.17.19"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
       },
       "peerDependencies": {
         "request": "^2.34"
@@ -10008,6 +9991,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20657,18 +20641,9 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
       "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -21117,7 +21092,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "mocha": "^10.2.0",
     "req-cwd": "^2.0.0",
     "request": "^2.88.0",
-    "request-promise-native": "^1.0.5",
     "sha1": "^1.1.1",
     "sync-request": "^6.0.0"
   },


### PR DESCRIPTION
The package request-promise-native is deprecated.
I replaced it using the already present package sync-request.